### PR TITLE
Refactor profile picture update logic to normalize JID and prevent un…

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -274,14 +274,14 @@ export const makeChatsSocket = (config: SocketConfig) => {
 
 	/** update the profile picture for yourself or a group */
 	const updateProfilePicture = async (jid: string, content: WAMediaUpload) => {
-		let targetJid = '';
+		let targetJid;
 		if (!jid) {
 			throw new Boom(
 				'Illegal no-jid profile update. Please specify either your ID or the ID of the chat you wish to update',
 			);
 		}
 		if (jidNormalizedUser(jid) !== jidNormalizedUser(authState.creds.me!.id)) {
-			targetJid = jid; // in case it is someone other than us
+			targetJid = jidNormalizedUser(jid); // in case it is someone other than us
 		}
 		const { img } = await generateProfilePicture(content);
 		await query({
@@ -304,14 +304,14 @@ export const makeChatsSocket = (config: SocketConfig) => {
 
 	/** remove the profile picture for yourself or a group */
 	const removeProfilePicture = async (jid: string) => {
-		let targetJid = '';
+		let targetJid;
 		if (!jid) {
 			throw new Boom(
 				'Illegal no-jid profile update. Please specify either your ID or the ID of the chat you wish to update',
 			);
 		}
 		if (jidNormalizedUser(jid) !== jidNormalizedUser(authState.creds.me!.id)) {
-			targetJid = jid; // in case it is someone other than us
+			targetJid = jidNormalizedUser(jid); // in case it is someone other than us
 		}
 		await query({
 			tag: 'iq',
@@ -874,8 +874,10 @@ export const makeChatsSocket = (config: SocketConfig) => {
 		let props: { [_: string]: string } = {};
 		if (propsNode) {
 			// @ts-ignore
-			authState?.creds?.lastPropHash = propsNode?.attrs?.hash;
-			ev.emit('creds.update', authState.creds);
+			if(propsNode.attrs?.hash) { // on some clients, the hash is returning as undefined
+				authState.creds.lastPropHash = propsNode?.attrs?.hash
+				ev.emit('creds.update', authState.creds)
+			}
 			props = reduceBinaryNodeToDictionary(propsNode, 'prop');
 		}
 


### PR DESCRIPTION
…defined hash errors

## Summary by Sourcery

Normalizes the JID when updating or removing a profile picture to ensure consistency. Also, it prevents errors caused by undefined hash values when updating credentials.

Bug Fixes:
- Fixes potential errors caused by undefined hash values when updating credentials.
- Normalizes JID to prevent undefined hash errors